### PR TITLE
BuildSpec: add buildContext for Docker build subdirectory support

### DIFF
--- a/shepherd-java-api/src/main/kotlin/Project.kt
+++ b/shepherd-java-api/src/main/kotlin/Project.kt
@@ -98,13 +98,23 @@ public data class Resources(
  * @property resources how many resources to allocate for the build. Passed via `BUILD_MEMORY` and `CPU_QUOTA` env variables to `shepherd-build`.
  * @property buildArgs optional build args, passed as `--build-arg name="value"` to `docker build` via the `BUILD_ARGS` env variable passed to `shepherd-build`.
  * @property dockerFile if not null, we build off this dockerfile instead of the default `Dockerfile`. Passed via `DOCKERFILE` env variable to `shepherd-build`.
+ * @property buildContext if not null, specifies the subdirectory to use as the Docker build context (e.g., 'demo' or 'services/api'). Passed via `BUILD_CONTEXT` env variable to `shepherd-build`.
  */
 @Serializable
 public data class BuildSpec @JvmOverloads constructor(
     val resources: Resources,
     val buildArgs: Map<String, String> = mapOf(),
-    val dockerFile: String? = null
-)
+    val dockerFile: String? = null,
+    val buildContext: String? = null
+) {
+    init {
+        if (buildContext != null) {
+            require(!buildContext.containsWhitespaces()) { "buildContext must not contain whitespaces" }
+            require(!buildContext.contains("..")) { "buildContext must not contain '..' (directory traversal)" }
+            require(!buildContext.startsWith("/")) { "buildContext must be a relative path" }
+        }
+    }
+}
 
 /**
  * A git repository.

--- a/shepherd-java-api/src/main/kotlin/SimpleJenkinsClient.kt
+++ b/shepherd-java-api/src/main/kotlin/SimpleJenkinsClient.kt
@@ -80,6 +80,9 @@ internal class SimpleJenkinsClient @JvmOverloads constructor(
         if (project.build.dockerFile != null) {
             envVars.add("export DOCKERFILE=${project.build.dockerFile}")
         }
+        if (project.build.buildContext != null) {
+            envVars.add("export BUILD_CONTEXT=${project.build.buildContext}")
+        }
         val credentials = if (project.gitRepo.credentialsID == null) {
             ""
         } else {
@@ -329,6 +332,7 @@ ${shepherdHome}/shepherd-build ${project.id.id.escapeXml()}</command>
         fun needsProjectRebuild(newProject: Project, oldProject: Project): Boolean =
             newProject.build.buildArgs != oldProject.build.buildArgs ||
                     newProject.build.dockerFile != oldProject.build.dockerFile ||
+                    newProject.build.buildContext != oldProject.build.buildContext ||
                     // also this: if e.g. build memory increases from 1024 to 2048, we want a full rebuild: the old project might have failed to build because there was not enough memory
                     newProject.build.resources.memoryMb != oldProject.build.resources.memoryMb ||
                     newProject.gitRepo != oldProject.gitRepo ||

--- a/shepherd-web/src/main/kotlin/ui/EditProjectRoute.kt
+++ b/shepherd-web/src/main/kotlin/ui/EditProjectRoute.kt
@@ -180,6 +180,15 @@ class ProjectForm(val creatingNew: Boolean) : KFormLayout(), Form<MutableProject
                 .validateNoWhitespaces()
                 .bind(MutableProject::buildDockerFile)
         }
+        textField("Build context: subdirectory to use as Docker build context (e.g., 'demo' or 'services/api'). Leave empty to use repository root.") {
+            setId("buildContext")
+            bind(binder)
+                .trimmingConverter()
+                .validateNoWhitespaces()
+                .withValidator({ it == null || !it.contains("..") }, "must not contain '..'")
+                .withValidator({ it == null || !it.startsWith("/") }, "must be a relative path")
+                .bind(MutableProject::buildContext)
+        }
         h3("Runtime") {
             colspan = 2
         }

--- a/shepherd-web/src/main/kotlin/ui/MutableProject.kt
+++ b/shepherd-web/src/main/kotlin/ui/MutableProject.kt
@@ -117,6 +117,8 @@ data class MutableProject(
     var buildArgs: Set<NamedVar>,
     @field:Length(max = 255)
     var buildDockerFile: String?,
+    @field:Length(max = 255)
+    var buildContext: String?,
 
     var publishOnMainDomain: Boolean,
     var publishAdditionalDomainsHttps: Boolean,
@@ -152,6 +154,7 @@ data class MutableProject(
             buildResourcesCpu = Resources.defaultBuildResources.cpu.toBigDecimal(),
             buildArgs = setOf(),
             buildDockerFile = null,
+            buildContext = null,
             publishOnMainDomain = true,
             publishAdditionalDomainsHttps = true,
             publishAdditionalDomains = mutableSetOf(),
@@ -198,7 +201,8 @@ data class MutableProject(
             build = BuildSpec(
                 Resources(buildResourcesMemoryMb, buildResourcesCpu.toFloat()),
                 buildArgs.associate { it.name to it.value },
-                dockerFile = buildDockerFile
+                dockerFile = buildDockerFile,
+                buildContext = buildContext
             ),
             publication = Publication(
                 publishOnMainDomain = publishOnMainDomain,
@@ -242,6 +246,7 @@ fun Project.toMutable(): MutableProject = MutableProject(
     buildResourcesCpu = build.resources.cpu.toBigDecimal(),
     buildArgs = build.buildArgs.map { NamedVar(it.key, it.value) } .toSet(),
     buildDockerFile = build.dockerFile,
+    buildContext = build.buildContext,
     publishOnMainDomain = publication.publishOnMainDomain,
     publishAdditionalDomainsHttps = publication.https,
     publishAdditionalDomains = publication.additionalDomains.toMutableSet(),


### PR DESCRIPTION
Adds support for specifying a build context subdirectory for Docker builds, allowing users to build Dockerfiles from subdirectories in monorepos. Addresses GitHub issue #20.

- Add buildContext field to BuildSpec with validation (no whitespaces, no directory traversal, must be relative path)
- Export BUILD_CONTEXT env var in Jenkins job XML
- Add buildContext to needsProjectRebuild() check
- Add UI field in EditProjectRoute
- Add tests for validation, serialization, and rebuild detection

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>